### PR TITLE
Adding modified date column to fact_orders

### DIFF
--- a/models/intermediate/int_sales__prep_orders.sql
+++ b/models/intermediate/int_sales__prep_orders.sql
@@ -21,6 +21,7 @@ with
             , freight
             , total_due
             , currency_rate_fk
+            , modified_date
         from {{ ref('stg_erp__sales_order_header') }}
     )
 
@@ -81,6 +82,7 @@ with
             , credit_card.card_type
             , sales_reason.reason_name
             , sales_reason.reason_type
+            , sales_order_header.modified_date
         from sales_order_header
         left join currency_rate on sales_order_header.currency_rate_fk = currency_rate.currency_rate_pk
         left join sales_order_header_sales_reason on sales_order_header.sales_order_pk = sales_order_header_sales_reason.sales_order_fk

--- a/models/intermediate/schema/int_sales__prep_orders.yml
+++ b/models/intermediate/schema/int_sales__prep_orders.yml
@@ -95,3 +95,7 @@ models:
       - name: reason_type
         data_type: varchar
         description: ""
+
+      - name: modified_date
+        data_type: date
+        description: ""

--- a/models/marts/schema/fct_orders.yml
+++ b/models/marts/schema/fct_orders.yml
@@ -99,3 +99,7 @@ models:
       - name: reason_type
         data_type: varchar
         description: "Category of the sales reason (e.g., Discount, Marketing, Referral)."
+
+      - name: modified_date
+        data_type: date
+        description: "Last date the record was modified."

--- a/models/staging/erp/schema/stg_erp__sales_order_header.yml
+++ b/models/staging/erp/schema/stg_erp__sales_order_header.yml
@@ -83,3 +83,7 @@ models:
       - name: total_due
         data_type: number
         description: ""
+
+      - name: modified_date
+        data_type: date
+        description: ""       

--- a/models/staging/erp/stg_erp__sales_order_header.sql
+++ b/models/staging/erp/stg_erp__sales_order_header.sql
@@ -31,7 +31,7 @@ with
             , cast(totaldue as float) as total_due
             --, cast(comment as string) as comment
             --, cast(rowguid as string) as row_guid
-            --, cast(modifieddate as date) as modified_date
+            , cast(modifieddate as date) as modified_date
         from sales_order_header
     )
 


### PR DESCRIPTION
**General Goal:**
Implement the modified_date column for fact_orders to be used as last update date on PBI dashboards.

**Specific Goals:**
Adding modified_date column to stg and downstream models;
Adding last update date using this column on PBI.

**✅ All tests passed successfully.**